### PR TITLE
Fix a copy error in the License section of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Unbounded is the product of a joint collaboration between [Studio Koto](https://
 
 ## License
 
-This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is copied below, and is also available with a FAQ [here](https://scripts.sil.org/OFL).
+This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ [here](https://scripts.sil.org/OFL).
 
 ## Authors
 


### PR DESCRIPTION
At commit [0dca1eb](https://github.com/w3f/unbounded/commit/0dca1ebf330f4df0f718c7602aa00b8abfd514bc) the License section of the README reads: 

> This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is copied below, and is also available with a FAQ [here](https://scripts.sil.org/OFL).

But there is no license copied below as claimed. This PR updates the License section to read: 

> This Font Software is licensed under the SIL Open Font License, Version 1.1. This license is available with a FAQ [here](https://scripts.sil.org/OFL).